### PR TITLE
Remove 'Release Group (Missing)' condition

### DIFF
--- a/custom_formats/Banned Groups.yml
+++ b/custom_formats/Banned Groups.yml
@@ -4,11 +4,6 @@ tags:
 - Banned
 - Release Group
 conditions:
-- name: Release Group (Missing)
-  negate: true
-  pattern: Release Group (Missing)
-  required: false
-  type: release_group
 - name: 4K4U
   negate: false
   pattern: 4K4U


### PR DESCRIPTION
Removed condition for 'Release Group (Missing)' from banned groups.